### PR TITLE
document how to populate the default image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ To build the images, run:
 
 
 ```shell
+vagrant box add ubuntu/trusty64
 AWS_SECRET_KEY=your_secret_key AWS_ACCESS_KEY=your_access_key packer build default.json
 ```


### PR DESCRIPTION
I get the error:

$ packer build -only=virtualbox-ovf default.json
virtualbox-ovf output will be in this color.
1 error(s) occurred:
- source_path is invalid: stat /Users/don/.vagrant.d/boxes/trusty64/0/virtualbox/box.ovf: no such file or directory

and the solution seems to be using vagrant to install the ubuntu/trusty64 default image
